### PR TITLE
feat: orchestrate swaps via FXRemit + fix broker ABI; wire frontend

### DIFF
--- a/packages/hardhat/contracts/FXRemit.sol
+++ b/packages/hardhat/contracts/FXRemit.sol
@@ -78,7 +78,7 @@ contract FXRemit is ReentrancyGuard, Ownable, Pausable {
     event SwapExecuted(
         uint256 indexed remittanceId,
         address providerAddr,
-        uint256 exchangeId,
+        bytes32 exchangeId,
         address fromToken,
         address toToken,
         uint256 amountIn,
@@ -117,7 +117,7 @@ contract FXRemit is ReentrancyGuard, Ownable, Pausable {
         string memory toCurrency,
         string memory corridor,
         address providerAddr,
-        uint256 exchangeId
+        bytes32 exchangeId
     ) external nonReentrant whenNotPaused returns (uint256 remittanceId, uint256 amountOut) {
         require(mentoBroker != address(0), "Broker not set");
         require(recipient != address(0), "Invalid recipient address");

--- a/packages/hardhat/contracts/interfaces/IMentoBroker.sol
+++ b/packages/hardhat/contracts/interfaces/IMentoBroker.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 interface IMentoBroker {
     function swapIn(
         address providerAddr,
-        uint256 exchangeId,
+        bytes32 exchangeId,
         address tokenIn,
         address tokenOut,
         uint256 amountIn,

--- a/packages/react-app/ABI/FXRemit.json
+++ b/packages/react-app/ABI/FXRemit.json
@@ -252,9 +252,9 @@
       },
       {
         "indexed": false,
-        "internalType": "uint256",
+        "internalType": "bytes32",
         "name": "exchangeId",
-        "type": "uint256"
+        "type": "bytes32"
       },
       {
         "indexed": false,
@@ -967,9 +967,9 @@
         "type": "address"
       },
       {
-        "internalType": "uint256",
+        "internalType": "bytes32",
         "name": "exchangeId",
-        "type": "uint256"
+        "type": "bytes32"
       }
     ],
     "name": "swapAndSend",

--- a/packages/react-app/ABI/IMento.json
+++ b/packages/react-app/ABI/IMento.json
@@ -1,40 +1,40 @@
 [
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "providerAddr",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "exchangeId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "tokenIn",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "tokenOut",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amountIn",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint256",
-          "name": "minAmountOut",
-          "type": "uint256"
-        }
-      ],
-      "name": "swapIn",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ]
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "providerAddr",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "exchangeId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapIn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/react-app/app/send/page.tsx
+++ b/packages/react-app/app/send/page.tsx
@@ -6,7 +6,6 @@ import { ConnectButton } from "@rainbow-me/rainbowkit"
 import BottomNavigation from "@/components/BottomNavigation"
 import { useTokenBalance, useQuote } from "@/hooks/useMento"
 import { useEthersSwap } from "@/hooks/useEthersSwap"
-import { useLogRemittance } from "@/hooks/useContract"
 import type { Currency } from "@/lib/contracts"
 import { toast } from "react-toastify"
 import Link from "next/link"
@@ -50,7 +49,6 @@ export default function SendPage() {
   const { balance, isLoading: isLoadingBalance } = useTokenBalance(fromCurrency)
   const { quote, isLoading: isLoadingQuote } = useQuote(fromCurrency, toCurrency, amount)
   const { swap } = useEthersSwap()
-  const { logRemittance, isPending: isLoggingRemittance } = useLogRemittance()
 
   const fromCurrencyInfo = currencies.find((c) => c.code === fromCurrency)
   const toCurrencyInfo = currencies.find((c) => c.code === toCurrency)
@@ -77,23 +75,6 @@ export default function SendPage() {
       const swapResult = await swap(fromCurrency, toCurrency, amount, undefined, recipient)
 
       console.log("✅ Swap completed successfully:", swapResult)
-
-      try {
-        await logRemittance({
-          recipient,
-          fromCurrency,
-          toCurrency,
-          amountSent: amount,
-          amountReceived: quote.amountOut,
-          exchangeRate: quote.exchangeRate,
-          platformFee: quote.platformFee,
-          mentoTxHash: swapResult.hash,
-          corridor: `${fromCurrency.replace("c", "")}-${toCurrency.replace("c", "")}`,
-        })
-        console.log("✅ logRemittance completed successfully!")
-      } catch (logError) {
-        console.error("❌ logRemittance failed:", logError)
-      }
 
       toast.dismiss(loadingToast)
       const successMessage = swapResult.message || `🎉 Successfully sent ${amount} ${fromCurrency} to ${recipient}!`
@@ -312,12 +293,12 @@ export default function SendPage() {
           {/* Send Button */}
           <button
             onClick={handleSend}
-            disabled={!isConnected || !amount || !recipient || !quote || isProcessing || isLoggingRemittance}
+            disabled={!isConnected || !amount || !recipient || !quote || isProcessing}
             className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 text-white font-bold py-4 px-8 rounded-xl transition-all duration-200 shadow-sm hover:shadow-md disabled:cursor-not-allowed text-lg flex items-center justify-center space-x-2"
           >
             {!isConnected ? (
               <span>Connect Wallet</span>
-            ) : isProcessing || isLoggingRemittance ? (
+            ) : isProcessing ? (
               <>
                 <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
                 <span>Processing...</span>

--- a/packages/react-app/hooks/useEthersSwap.ts
+++ b/packages/react-app/hooks/useEthersSwap.ts
@@ -1,10 +1,11 @@
 import { useAccount, useWalletClient, usePublicClient } from 'wagmi';
 import { Mento } from '@mento-protocol/mento-sdk';
 import { providers, Wallet, utils, Contract } from 'ethers';
-import { Currency, getTokenAddress } from '../lib/contracts';
-import { parseEther, formatEther } from 'viem';
+import { Currency, getTokenAddress, getContractAddress } from '../lib/contracts';
+import { parseEther, formatEther, encodeFunctionData, type Abi } from 'viem';
 import { celo } from 'viem/chains';
 import { useDivvi } from './useDivvi';
+import FXRemitABI from '../ABI/FXRemit.json';
 
 // Pure ethers.js implementation following official Mento SDK examples
 export function useEthersSwap() {
@@ -92,17 +93,10 @@ export function useEthersSwap() {
     const signer = createProperSigner(address);
     
     console.log('✨ Creating Mento SDK...');
-    
     const mento = await Mento.create(signer);
-    
-    // Initialize exchanges - this is likely what's missing!
-    console.log('🔄 Initializing exchanges...');
+    console.log('🔄 Loading exchanges...');
     const exchanges = await mento.getExchanges();
-    console.log('📊 Available exchanges:', exchanges.length);
-    
-    if (exchanges.length === 0) {
-      throw new Error('No exchanges found - cannot perform swaps');
-    }
+    if (exchanges.length === 0) throw new Error('No exchanges found');
     
     // Use viem's parseEther to avoid BigNumber version issues
     const amountInWei = parseEther(amount);
@@ -120,537 +114,88 @@ export function useEthersSwap() {
     const quoteBigInt = BigInt(quoteAmountOut.toString());
     const expectedAmountOut = minAmountOut 
       ? parseEther(minAmountOut).toString()
-      : (quoteBigInt * BigInt(99) / BigInt(100)).toString();
+      : (quoteBigInt * BigInt(98) / BigInt(100)).toString(); // default 2% slippage
     
     console.log(`🎯 Expected amount out with 1% slippage: ${formatEther(BigInt(expectedAmountOut))} ${toCurrency}`);
     
     try {
-      // First, find the tradable pair like in the official examples
-      console.log('🔍 Finding tradable pair for swap...');
-      const tradablePair = await mento.findPairForTokens(
-        fromTokenAddress,
-        toTokenAddress
-      );
-      console.log('✅ Found tradable pair:', tradablePair);
-      
-      // Skip allowance step for now to test if the swap works
-      console.log('⚠️ Skipping allowance step for now - will handle after finding broker contract');
-      
-      // Step 2: Perform swap (following official example)
-      console.log('🔄 Swapping tokens...');
-      console.log('Debug - Swap parameters:', {
-        fromTokenAddress,
-        toTokenAddress,
-        amountInWei: amountInWei.toString(),
-        expectedAmountOut
-      });
-      
-      console.log('🔍 Trying direct provider approach...');
-      
-      const mentoWithProvider = await Mento.create(provider);
-      console.log('📊 Mento with provider created');
-      
-      // Try to use the getBroker method to get the broker contract
-      const broker = await mento.getBroker();
-      console.log('📊 Broker contract initialized');
-      
-      // Handle token allowance for broker contract
-      console.log('🔓 Handling token allowance for broker contract...');
-      
-      // Known broker contract address for Celo mainnet
-      const brokerAddress = '0x777A8255cA72412f0d706dc03C9D1987306B4CaD';
-      
-      // Create token contract interface
-      const tokenInterface = ['function allowance(address owner, address spender) view returns (uint256)', 'function approve(address spender, uint256 amount) returns (bool)'];
+      // 1) Find tradable pair and correct single-hop exchange
+      const tradablePair = await mento.findPairForTokens(fromTokenAddress, toTokenAddress);
+      if (!tradablePair || tradablePair.path.length !== 1) {
+        throw new Error(`Unsupported path length: ${tradablePair?.path.length ?? 0}`);
+      }
+      const hop = tradablePair.path[0];
+      const providerAddr = hop.providerAddr as `0x${string}`;
+      const exchangeId = hop.id as `0x${string}`; // bytes32 id from Mento
+      console.log('📍 Using exchange hop', { providerAddr, exchangeId });
+
+      // 2) Approve FXRemit to spend the input token
+      const fxRemitAddress = getContractAddress(chainId);
+      if (!fxRemitAddress) throw new Error('FXRemit address not configured');
+      const tokenInterface = [
+        'function allowance(address owner, address spender) view returns (uint256)',
+        'function approve(address spender, uint256 amount) returns (bool)'
+      ];
       const tokenContract = new Contract(fromTokenAddress, tokenInterface, signer);
-      
-      // Step 1: Check current allowance
-      const currentAllowance = await tokenContract.allowance(signer.address, brokerAddress);
-      
-      // Step 2: Approve if needed
+      const currentAllowance = await tokenContract.allowance(signer.address, fxRemitAddress);
       if (BigInt(currentAllowance.toString()) < BigInt(amountInWei.toString())) {
-        console.log('🔓 Approving broker contract to spend tokens...');
-        
-        // Create approval transaction
         const approvalTx = await tokenContract.populateTransaction.approve(
-          brokerAddress,
+          fxRemitAddress,
           amountInWei.toString()
         );
-        
-        // Send approval transaction using viem
         const approvalHash = await walletClient.sendTransaction({
           account: signer.address as `0x${string}`,
           to: fromTokenAddress as `0x${string}`,
-          data: addReferralTagToTransaction(approvalTx.data as string) as `0x${string}`,
+          data: approvalTx.data as `0x${string}`,
           value: BigInt(0),
           kzg: undefined,
           chain: celo
         });
-        
-        console.log('📤 Approval transaction hash:', approvalHash);
-        
-        // Wait for approval transaction
         await publicClient.waitForTransactionReceipt({ hash: approvalHash });
-        console.log('✅ Approval confirmed!');
+        // Do not submit Divvi referral for approvals
+      }
 
-        // Submit Divvi referral for approval transaction
-        await submitReferralTransaction(approvalHash);
-      } else {
-        console.log('✅ Sufficient allowance already exists');
-      }
-      
-      // Check if trading is enabled for this pair
-      try {
-        const tradingEnabled = await mento.isTradingEnabled(tradablePair.id);
-        console.log('📊 Trading enabled:', tradingEnabled);
-      } catch (error) {
-        // Trading check failed, continue anyway
-      }
-      
-      // Find the correct exchange from the exchanges array
-      console.log('📊 Path length:', tradablePair.path.length);
-      
-      // Handle multi-hop swaps by using the path
-      if (tradablePair.path.length === 1) {
-        // Direct swap - single exchange
-        const correctExchange = exchanges.find(exchange => {
-          const hasTokens = exchange.assets.length === 2 &&
-            ((exchange.assets[0] === fromTokenAddress && exchange.assets[1] === toTokenAddress) ||
-             (exchange.assets[0] === toTokenAddress && exchange.assets[1] === fromTokenAddress));
-          return hasTokens;
-        });
-        console.log('📊 Found correct exchange:', correctExchange?.id);
-        
-        if (!correctExchange) {
-          throw new Error(`No direct exchange found for tokens ${fromTokenAddress} and ${toTokenAddress}`);
-        }
-             } else if (tradablePair.path.length === 2) {
-         // Multi-hop swap - manual implementation using two sequential swaps
-         console.log('🔄 Multi-hop swap detected');
-         
-         // Get the intermediate token (cUSD in most cases)
-         const firstExchange = tradablePair.path[0];
-         const secondExchange = tradablePair.path[1];
-         
-         // Find intermediate token by checking which token is common between both exchanges
-         let intermediateTokenAddress;
-         const firstAssets = firstExchange.assets;
-         const secondAssets = secondExchange.assets;
-         
-         // Find common asset (intermediate token)
-         for (const asset1 of firstAssets) {
-           for (const asset2 of secondAssets) {
-             if (asset1 === asset2 && asset1 !== fromTokenAddress && asset1 !== toTokenAddress) {
-               intermediateTokenAddress = asset1;
-               break;
-             }
-           }
-           if (intermediateTokenAddress) break;
-         }
-         
-         if (!intermediateTokenAddress) {
-           throw new Error('Could not determine intermediate token for multi-hop swap');
-         }
-         
-         console.log('🔄 Route: ', `${fromCurrency} → Intermediate → ${toCurrency}`);
-         
-         // Determine which exchange to use for each step
-         // Step 1: fromToken → intermediateToken
-         // Step 2: intermediateToken → toToken
-         
-         let step1Exchange, step2Exchange;
-         
-         // Find exchange that contains fromToken and intermediateToken
-         for (const exchange of [firstExchange, secondExchange]) {
-           const hasFromToken = exchange.assets.includes(fromTokenAddress);
-           const hasIntermediateToken = exchange.assets.includes(intermediateTokenAddress);
-           if (hasFromToken && hasIntermediateToken) {
-             step1Exchange = exchange;
-             break;
-           }
-         }
-         
-         // Find exchange that contains intermediateToken and toToken  
-         for (const exchange of [firstExchange, secondExchange]) {
-           const hasIntermediateToken = exchange.assets.includes(intermediateTokenAddress);
-           const hasToToken = exchange.assets.includes(toTokenAddress);
-           if (hasIntermediateToken && hasToToken) {
-             step2Exchange = exchange;
-             break;
-           }
-         }
-         
-         if (!step1Exchange || !step2Exchange) {
-           throw new Error('Could not find appropriate exchanges for multi-hop swap');
-         }
-         
-         // Step 1: Swap fromToken to intermediate token
-         console.log('📍 Step 1: Swapping to intermediate token...');
-         
-         // Get quote for first step using broker contract instead of Mento SDK
-         const step1Quote = await broker.functions.getAmountOut(
-           step1Exchange.providerAddr,
-           step1Exchange.id,
-           fromTokenAddress,
-           intermediateTokenAddress,
-           amountInWei.toString()
-         );
-         
-         // Apply slippage to step1 (1% slippage)  
-         const step1MinAmount = (BigInt(step1Quote.toString()) * BigInt(99)) / BigInt(100);
-         
-         // Execute first swap
-         const step1TxRequest = await broker.interface.encodeFunctionData('swapIn', [
-           step1Exchange.providerAddr,
-           step1Exchange.id,
-           fromTokenAddress,
-           intermediateTokenAddress,
-           amountInWei.toString(),
-           step1MinAmount.toString()
-         ]);
-         
-         // Add Divvi referral tag to step 1 transaction data
-         const step1DataWithReferral = addReferralTagToTransaction(step1TxRequest);
-         
-         const step1Hash = await walletClient.sendTransaction({
-           account: signer.address as `0x${string}`,
-           to: brokerAddress as `0x${string}`,
-           data: step1DataWithReferral as `0x${string}`,
-           value: BigInt(0),
-           kzg: undefined,
-           chain: celo
-         });
-         
-         console.log('📤 Step 1 transaction hash:', step1Hash);
-         
-         // Wait for step 1 to complete
-         await publicClient.waitForTransactionReceipt({ hash: step1Hash });
-         console.log('✅ Step 1 complete');
-         
-         // Submit referral for step 1
-         console.log('📬 Submitting referral for step 1 to Divvi...');
-         await submitReferralTransaction(step1Hash);
-         
-         // Step 2: Approve intermediate token for broker (if needed)
-         const intermediateTokenContract = new Contract(
-           intermediateTokenAddress,
-           ['function allowance(address owner, address spender) view returns (uint256)', 'function approve(address spender, uint256 amount) returns (bool)'],
-           signer
-         );
-         
-         const intermediateAllowance = await intermediateTokenContract.allowance(signer.address, brokerAddress);
-         
-        if (BigInt(intermediateAllowance.toString()) < BigInt(step1Quote.toString())) {
-           const approvalTx = await intermediateTokenContract.populateTransaction.approve(
-             brokerAddress,
-             step1Quote.toString()
-           );
-           
-          const approvalHash = await walletClient.sendTransaction({
-             account: signer.address as `0x${string}`,
-             to: intermediateTokenAddress as `0x${string}`,
-            data: addReferralTagToTransaction(approvalTx.data as string) as `0x${string}`,
-             value: BigInt(0),
-             kzg: undefined,
-             chain: celo
-           });
-           
-           await publicClient.waitForTransactionReceipt({ hash: approvalHash });
-           console.log('✅ Intermediate token approved');
-
-          // Submit Divvi referral for approval transaction
-          await submitReferralTransaction(approvalHash);
-         }
-         
-         // Step 2: Swap intermediate token to target token
-         console.log('📍 Step 2: Swapping intermediate to target token...');
-         
-         // Get quote for second step
-         const step2Quote = await broker.functions.getAmountOut(
-           step2Exchange.providerAddr,
-           step2Exchange.id,
-           intermediateTokenAddress,
-           toTokenAddress,
-           step1Quote.toString()
-         );
-         
-         // Apply slippage to step2 (1% slippage)
-         const step2MinAmount = (BigInt(step2Quote.toString()) * BigInt(99)) / BigInt(100);
-         
-         const step2TxRequest = await broker.interface.encodeFunctionData('swapIn', [
-           step2Exchange.providerAddr,
-           step2Exchange.id,
-           intermediateTokenAddress,
-           toTokenAddress,
-           step1Quote.toString(),
-           step2MinAmount.toString()
-         ]);
-         
-         // Add Divvi referral tag to step 2 transaction data
-         const step2DataWithReferral = addReferralTagToTransaction(step2TxRequest);
-         
-         const step2Hash = await walletClient.sendTransaction({
-           account: signer.address as `0x${string}`,
-           to: brokerAddress as `0x${string}`,
-           data: step2DataWithReferral as `0x${string}`,
-           value: BigInt(0),
-           kzg: undefined,
-           chain: celo
-         });
-         
-         console.log('📤 Step 2 transaction hash:', step2Hash);
-         
-         // Wait for step 2 to complete
-         await publicClient.waitForTransactionReceipt({ hash: step2Hash });
-         console.log('✅ Step 2 complete');
-         
-         // Submit referral for step 2
-         console.log('📬 Submitting referral for step 2 to Divvi...');
-         await submitReferralTransaction(step2Hash);
-         
-         // Handle remittance if recipient address is provided and different from sender
-         if (recipientAddress && recipientAddress !== signer.address) {
-           console.log('🔄 Transferring tokens to recipient...');
-           
-           const outputTokenContract = new Contract(toTokenAddress, ['function transfer(address to, uint256 amount) returns (bool)'], signer);
-           
-           const transferTx = await outputTokenContract.populateTransaction.transfer(
-             recipientAddress,
-             step2Quote.toString()
-           );
-           
-           // Add Divvi referral tag to transfer transaction data
-           const transferDataWithReferral = addReferralTagToTransaction(transferTx.data as string);
-           
-           const transferHash = await walletClient.sendTransaction({
-             account: signer.address as `0x${string}`,
-             to: toTokenAddress as `0x${string}`,
-             data: transferDataWithReferral as `0x${string}`,
-             value: BigInt(0),
-             kzg: undefined,
-             chain: celo
-           });
-           
-           await publicClient.waitForTransactionReceipt({ hash: transferHash });
-           console.log('✅ Transfer to recipient confirmed!');
-           
-           // Submit referral for transfer transaction
-           console.log('📬 Submitting referral for transfer to Divvi...');
-           await submitReferralTransaction(transferHash);
-           
-           return {
-             success: true,
-             hash: step2Hash,
-             transferHash,
-             amountOut: formatEther(BigInt(step2Quote.toString())),
-             recipient: recipientAddress,
-             message: `Successfully sent ${formatEther(BigInt(step2Quote.toString()))} ${toCurrency} to ${recipientAddress}!`
-           };
-         } else {
-           return {
-             success: true,
-             hash: step2Hash,
-             amountOut: formatEther(BigInt(step2Quote.toString())),
-             recipient: signer.address,
-             message: `Successfully swapped ${formatEther(BigInt(amountInWei))} ${fromCurrency} for ${formatEther(BigInt(step2Quote.toString()))} ${toCurrency}!`
-           };
-         }
-      } else {
-        throw new Error(`Unsupported swap path length: ${tradablePair.path.length}`);
-      }
-      
-      // Continue with direct swap logic for single-hop swaps
-      const correctExchange = exchanges.find(exchange => {
-        const hasTokens = exchange.assets.length === 2 &&
-          ((exchange.assets[0] === fromTokenAddress && exchange.assets[1] === toTokenAddress) ||
-           (exchange.assets[0] === toTokenAddress && exchange.assets[1] === fromTokenAddress));
-        return hasTokens;
+      // 3) Call FXRemit.swapAndSend with SDK-provided params
+      const corridor = `${fromCurrency}-${toCurrency}`;
+      const calldata = encodeFunctionData({
+        abi: FXRemitABI as unknown as Abi,
+        functionName: 'swapAndSend',
+        args: [
+          (recipientAddress ?? signer.address) as `0x${string}`,
+          fromTokenAddress as `0x${string}`,
+          toTokenAddress as `0x${string}`,
+          amountInWei,
+          BigInt(expectedAmountOut),
+          fromCurrency,
+          toCurrency,
+          corridor,
+          providerAddr,
+          exchangeId
+        ]
       });
-      console.log('📊 Found correct exchange:', correctExchange?.id);
-      
-      if (!correctExchange) {
-        throw new Error(`No exchange found for tokens ${fromTokenAddress} and ${toTokenAddress}`);
-      }
-      
-      // Try different swap approaches
-      try {
-        // Method 1: Try calling broker directly with the function interface
-        console.log('🔄 Trying direct broker function call...');
-        
-        // Create the transaction request instead of executing it
-        // Note: Broker swapIn always sends output tokens to caller, not custom recipient
-        const txRequest = await broker.interface.encodeFunctionData('swapIn', [
-          correctExchange.providerAddr,  // exchangeProvider
-          correctExchange.id,            // exchangeId  
-          fromTokenAddress,              // tokenIn
-          toTokenAddress,                // tokenOut
-          amountInWei.toString(),        // amountIn
-          expectedAmountOut              // amountOutMin
-        ]);
-        
-        // Add Divvi referral tag to transaction data
-        const transactionDataWithReferral = addReferralTagToTransaction(txRequest);
-        
-        // Send the transaction using viem directly
-        const hash = await walletClient.sendTransaction({
+
+      const dataWithReferral = addReferralTagToTransaction(calldata);
+      const hash = await walletClient.sendTransaction({
           account: signer.address as `0x${string}`,
-          to: brokerAddress as `0x${string}`,
-          data: transactionDataWithReferral as `0x${string}`,
-          value: BigInt(0),
-          kzg: undefined,
-          chain: celo
-        });
-        
-        console.log('📤 Transaction hash:', hash);
-        console.log('✅ Direct broker function call succeeded!');
-        
-        // Wait for swap transaction to be mined
-        await publicClient.waitForTransactionReceipt({ hash });
-        console.log('✅ Swap transaction confirmed!');
-        
-        // Submit referral to Divvi after transaction confirmation
-        console.log('📬 Submitting referral to Divvi...');
-        await submitReferralTransaction(hash);
-        
-        // Handle remittance if recipient address is provided and different from sender
-        if (recipientAddress && recipientAddress !== signer.address) {
-          console.log('🔄 Transferring received tokens to recipient...');
-          
-          // Create token contract for the output token
-          const outputTokenContract = new Contract(toTokenAddress, ['function transfer(address to, uint256 amount) returns (bool)'], signer);
-          
-          // Transfer the received tokens to the recipient
-          const transferTx = await outputTokenContract.populateTransaction.transfer(
-            recipientAddress,
-            expectedAmountOut
-          );
-          
-          console.log('📋 Transfer transaction:', transferTx);
-          
-          // Add Divvi referral tag to transfer transaction data
-          const transferDataWithReferral = addReferralTagToTransaction(transferTx.data as string);
-          
-                     // Send transfer transaction using viem
-           const transferHash = await walletClient.sendTransaction({
-             account: signer.address as `0x${string}`,
-             to: toTokenAddress as `0x${string}`,
-             data: transferDataWithReferral as `0x${string}`,
+        to: fxRemitAddress as `0x${string}`,
+        data: dataWithReferral as `0x${string}`,
              value: BigInt(0),
              kzg: undefined,
              chain: celo
            });
-          
-                   console.log('📤 Transfer transaction hash:', transferHash);
-         
-         // Wait for transfer transaction
-         await publicClient.waitForTransactionReceipt({ hash: transferHash });
-         console.log('✅ Transfer confirmed!');
-          
-          // Submit referral for transfer transaction
-          console.log('📬 Submitting referral for transfer to Divvi...');
-          await submitReferralTransaction(transferHash);
-          
-          return {
-            success: true,
-            hash,
-            transferHash,
-            amountOut: formatEther(BigInt(expectedAmountOut)),
-            recipient: recipientAddress,
-            message: `Successfully sent ${formatEther(BigInt(expectedAmountOut))} ${toCurrency} to ${recipientAddress}!`
-          };
-        } else {
-          return {
-            success: true,
-            hash,
-            amountOut: formatEther(BigInt(expectedAmountOut)),
-            recipient: signer.address,
-            message: `Successfully swapped ${formatEther(BigInt(amountInWei))} ${fromCurrency} for ${formatEther(BigInt(expectedAmountOut))} ${toCurrency}!`
-          };
-        }
-      } catch (error1) {
-        console.log('Method 1 failed:', error1 instanceof Error ? error1.message : String(error1));
-        
-        try {
-          // Method 2: Try alternative broker function call
-          console.log('🔄 Trying alternative broker function signature...');
-          // Alternative signature with additional parameters
-          const txRequest = await broker.interface.encodeFunctionData('swapIn', [
-            correctExchange.providerAddr,
-            correctExchange.id,
-            fromTokenAddress,
-            toTokenAddress,
-            amountInWei.toString(),
-            expectedAmountOut
-          ]);
-          
-                                          // Add Divvi referral tag to transaction data
-           const transactionDataWithReferral = addReferralTagToTransaction(txRequest);
-           
-           const hash = await walletClient.sendTransaction({
-             account: signer.address as `0x${string}`,
-             to: brokerAddress as `0x${string}`,
-             data: transactionDataWithReferral as `0x${string}`,
-             value: BigInt(0),
-             kzg: undefined,
-             chain: celo
-           });
-          
-          await publicClient.waitForTransactionReceipt({ hash });
-          console.log('✅ Alternative broker call succeeded!');
-          
-          // Submit referral to Divvi after transaction confirmation
-          console.log('📬 Submitting referral to Divvi...');
-          await submitReferralTransaction(hash);
-          
-          return {
-            success: true,
-            hash,
-            amountOut: formatEther(BigInt(expectedAmountOut)),
-            recipient: signer.address,
-            message: `Successfully swapped ${formatEther(BigInt(amountInWei))} ${fromCurrency} for ${formatEther(BigInt(expectedAmountOut))} ${toCurrency}!`
-          };
-        } catch (error2) {
-          console.log('Method 2 failed:', error2 instanceof Error ? error2.message : String(error2));
-          // If all methods fail, throw an error with diagnostic info
-          // Method 4: List all available functions on the broker
-          console.log('🔍 Listing all broker interface functions...');
-          const brokerInterface = broker.interface;
-          console.log('Broker interface:', brokerInterface);
-          console.log('Broker interface functions:', Object.getOwnPropertyNames(brokerInterface));
-          console.log('Broker methods:', Object.getOwnPropertyNames(broker));
-          // List all available functions by name - handle Map structure
-          console.log('📋 Available broker functions:');
-          const interfaceAny = brokerInterface as any;
-          if (interfaceAny.fragments) {
-            interfaceAny.fragments.forEach((fragment: any) => {
-              if (fragment.type === 'function') {
-                const signature = `${fragment.name}(${fragment.inputs.map((input: any) => `${input.type} ${input.name}`).join(', ')})`;
-                console.log(`- ${signature}`);
-              }
-            });
-          }
-          // Try to find swap-related functions from fragments
-          const swapFunctions: string[] = [];
-          const exchangeFunctions: string[] = [];
-          if (interfaceAny.fragments) {
-            interfaceAny.fragments.forEach((fragment: any) => {
-              if (fragment.type === 'function') {
-                const name = fragment.name.toLowerCase();
-                if (name.includes('swap')) {
-                  swapFunctions.push(fragment.name);
-                }
-                if (name.includes('exchange') || name.includes('trade')) {
-                  exchangeFunctions.push(fragment.name);
-                }
-              }
-            });
-          }
-          console.log('🔄 Swap-related functions:', swapFunctions);
-          console.log('💱 Exchange/Trade-related functions:', exchangeFunctions);
-          // If all methods fail, throw an error with diagnostic info
-          throw new Error(`All swap methods failed. Exchanges: ${exchanges.length}, Available methods: ${Object.getOwnPropertyNames(mento).join(', ')}`);
-        }
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== 'success') {
+        throw new Error('Swap failed on-chain');
       }
+      await submitReferralTransaction(hash);
+          
+          return {
+            success: true,
+            hash,
+            amountOut: formatEther(BigInt(expectedAmountOut)),
+        recipient: (recipientAddress ?? signer.address),
+        message: `Sent ${amount} ${fromCurrency} → ${toCurrency}`
+      };
       
     } catch (error) {
       console.error('❌ Swap failed:', error);

--- a/packages/react-app/lib/contracts.ts
+++ b/packages/react-app/lib/contracts.ts
@@ -2,7 +2,7 @@ import FXRemitABI from '../ABI/FXRemit.json';
 
 export const CONTRACT_ADDRESSES = {
   // Celo Mainnet
-  42220: process.env.NEXT_PUBLIC_FXREMIT_CONTRACT || '',
+  42220: process.env.NEXT_PUBLIC_FXREMIT_CONTRACT || '0x6Dc149722dAd32b906E7E5C349996e959fE8FeAc',
 } as const;
 
 export const FXREMIT_CONTRACT = {


### PR DESCRIPTION
Context: We wanted all value-generating actions (swap + send) to reflect on FXRemit rather than only logging after-the-fact.

What we built (contract):

- Added swapAndSend(...) orchestrator on FXRemit that pulls fromToken, approves the Mento Broker, calls swapIn, takes fee in output token, transfers net to recipient, and records analytics.

- Hardened validations: token support, providerAddr non-zero, currency/corridor consistency (symbols must match), non-zero amounts, pausable + nonReentrant.

- Accounted for fee-on-transfer tokens by measuring actualIn from pre/post balances and computing exchangeRate from actualIn.

- Safe approvals with SafeERC20.forceApprove (zero then set).

- New events: SwapExecuted, TokensTransferred; retained RemittanceLogged + PlatformStatsUpdated.

- Admin: setBroker, setFeeBps (max 10%), withdrawTokenFees, pause/unpause; emitted BrokerUpdated, FeeBpsUpdated.

- Fixed Broker ABI: exchangeId is bytes32 (not uint256). Updated IMentoBroker + FXRemit to use bytes32 and forward it to swapIn.

- Enabled viaIR in Hardhat to resolve a 'Stack too deep' compile error.

What we built (frontend):

- Route swaps through FXRemit.swapAndSend; still use Mento SDK to discover providerAddr + exchangeId (bytes32), and to get quotes for slippage.

- Approval now targets FXRemit (not Broker).

- Kept Divvi referral tagging only on the FXRemit.swapAndSend transaction. Removed tagging from ERC20 approvals (tokens reject extra calldata).

- Removed the separate logRemittance call (contract now logs internally); this also resolved a 400 from Divvi when trying to submit a non-tagged, non-value tx.

- Fixed calldata encoding: pass bigint for amountIn/minOut, pass bytes32 hop.id from SDK, ensure we use the single-hop exchange from findPairForTokens().

- Default slippage loosened to 2% to reduce revert risk; still user-adjustable later.

Issues we hit & how we fixed them:

- Approval revert: appending Divvi tag to ERC20 approve reverted on cUSD. Fix: approvals are untagged; only the main swap tx is tagged.

- Runtime revert: calling Broker with wrong exchangeId type (uint256) caused ABI mismatch revert. Fix: changed to bytes32 across interface/contract/frontend.

- Calldata types: passing strings for uint256 led to bad encoding. Fix: send bigint values via viem.

- Path params: using the wrong exchange reference initially. Fix: use tradablePair.path[0] {providerAddr, id}.

- Double logging + Divvi 400: calling logRemittance post-swap caused a referral submit error. Fix: rely solely on swapAndSend logging and submit referral for that tx only.

Security & correctness improvements:

- ReentrancyGuard + Pausable on state-changing paths.

- Fee-on-transfer support for inputs; platform fee charged on output.

- Corridor/ticker matching prevents spoofed display metadata.

- Events indexed for analytics; admin events emitted.

Deploy & config:

- Deploy script now sets the official Mento Broker on Celo mainnet (0x777A...4CaD) right after deployment.

- New mainnet FXRemit address configured in the frontend.

Current status:

- Single-hop corridors (e.g., cUSD -> cNGN/cKES/...) work end-to-end: one approve (first time), one swapAndSend tx, full on-chain logging, Divvi attribution on the swap tx.

- Multi-hop (e.g., cNGN -> cKES via cUSD) is not yet implemented; next step is a swapAndSendPath(hops[]) variant.